### PR TITLE
Plugin loads empty content currently

### DIFF
--- a/wp-plugin/mce-revisions.php
+++ b/wp-plugin/mce-revisions.php
@@ -132,7 +132,7 @@ function vrev_load_revisions_content($content) {
 	$runonce = true;
 	if ( $post->post_status == 'publish' || $post->post_status == 'future' ) {
 		$meta = get_post_meta($post_ID, '_ice_revisions_content');
-		$content = (string) array_pop($meta);
+		$content = empty($meta) ? $content : (string) array_pop($meta);
 	}
 
 	return $content;


### PR DESCRIPTION
I edited #135 to load content anyway if no meta exists for the post (post was created prior to plugin installation).

This is my first git edit so forgive me if I am misunderstanding the code or this process!
