### PR TITLE
Adding a GitHub Ribbon to the demo page so finding the source code is

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -153,5 +153,6 @@
 		</script>
 
 	</div>
+	<a href="http://github.com/NYTimes/ice"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://a248.e.akamai.net/assets.github.com/img/7afbc8b248c68eb468279e8c17986ad46549fb71/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub"></a>
 </body>
 </html>


### PR DESCRIPTION
a bit easier.

I saw the first few comments here: 

http://news.ycombinator.com/item?id=3573496

Decided to grab a ribbon from here:

https://github.com/blog/273-github-ribbons
