### PR TITLE
Updated 'getCleanContent' in api to not clone events when cloning nodes.

### DIFF
--- a/src/ice.js
+++ b/src/ice.js
@@ -376,9 +376,9 @@ InlineChangeEditor.prototype = {
 			if(typeof body === 'string')
 				body = ice.dom.create('<div>' + body + '</div>');
 			else
-				body = ice.dom.cloneNode(body)[0];
+				body = ice.dom.cloneNode(body, false)[0];
 		} else {
-			body = ice.dom.cloneNode(this.element)[0];
+			body = ice.dom.cloneNode(this.element, false)[0];
 		}
 		var changes = ice.dom.find(body, classList);
 		ice.dom.each(changes, function(el, i) {


### PR DESCRIPTION
I feel there is an issue with keeping the events attached to cloned nodes when calling getCleanContent. It causes issues when there are event handlers added to the tracked text. 

My specific use case is that I show a popup on the inserted or deleted text to allow the editor to accept or reject the change.
