### PR TITLE
Allow content to consist entirely of any block element, not only p

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -22,6 +22,7 @@ dom.DOCUMENT_FRAGMENT_NODE = 11;
 dom.NOTATION_NODE = 12;
 dom.CHARACTER_UNIT = 'character';
 dom.WORD_UNIT = 'word';
+dom.BLOCK_ELEMENTS = ['p', 'div', 'pre', 'ul', 'ol', 'li', 'table', 'tbody', 'td', 'th', 'fieldset', 'form', 'blockquote', 'dl', 'dir', 'center', 'address', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'img'];
 
 dom.getKeyChar = function (e) {
 	return String.fromCharCode(e.which);
@@ -202,38 +203,7 @@ dom.getIframeDocument = function (iframe) {
 	return doc;
 };
 dom.isBlockElement = function (element) {
-	switch (element.nodeName.toLowerCase()) {
-	case 'p':
-	case 'div':
-	case 'pre':
-	case 'ul':
-	case 'ol':
-	case 'li':
-	case 'table':
-	case 'tbody':
-	case 'td':
-	case 'th':
-	case 'fieldset':
-	case 'form':
-	case 'blockquote':
-	case 'dl':
-	case 'dir':
-	case 'center':
-	case 'address':
-	case 'h1':
-	case 'h2':
-	case 'h3':
-	case 'h4':
-	case 'h5':
-	case 'h6':
-	case 'img':
-		return true;
-		break;
-	default:
-		return false;
-		break;
-	}
-	return false;
+	return dom.BLOCK_ELEMENTS.lastIndexOf(element.nodeName.toLowerCase()) != -1;
 };
 dom.isStubElement = function (element) {
 	if (element) {

--- a/src/ice.js
+++ b/src/ice.js
@@ -111,7 +111,8 @@ InlineChangeEditor.prototype = {
 	 */
 	initializeRange: function() {
 		var range = this.selection.createRange();
-		range.setStart(ice.dom.find(this.element, this.blockEl)[0], 0);
+		var first_block_element = ice.dom.find(this.element, ice.dom.BLOCK_ELEMENTS.join(','))[0];
+		range.setStart(first_block_element, 0);
 		range.collapse(true);
 		this.selection.addRange(range);
 		if(this.env.frame)


### PR DESCRIPTION
Currently when initializing ice's range the
content must have at least one p element.

In most of the cases it's ok, but sometimes we
want it to be only h1 or a list and this causes
a NOT_FOUND dom exception.

To initialize the range, we take the first block
element, not the first this.blockEl (which is p).
