### PR TITLE
Expose internal IceChangeEditor instance in TinyMCE plugin

### DIFF
--- a/lib/tinymce/jscripts/tiny_mce/plugins/ice/editor_plugin.js
+++ b/lib/tinymce/jscripts/tiny_mce/plugins/ice/editor_plugin.js
@@ -121,6 +121,14 @@
 			});
 			
 			/**
+			 * Returns reference to internal ice instance for external manipulation.
+			 * @return internal IceChangeEditor instance
+			 */
+			ed.addCommand('ice_getinstance', function() {
+				return changeEditor;
+			});
+			
+			/**
 			 * Re-initializes ice's environment - resets the environment variables for the current page
 			 * and re-initializes the internal ice range. This is useful after tinymce hides/switches
 			 * the current editor, like when toggling to the html source view and back.


### PR DESCRIPTION
Added a command to TinyMCE (via existing ice plugin) to expose the
internal IceChangeEditor to allow plugins and external code access to
the ice API.
