### PR TITLE
prevent default when deleting from the beginning or end

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,8 +3,8 @@
 
 <head>
 	<link rel="stylesheet" href="demo.css" type="text/css" media="screen" />
-        <script src="http://code.jquery.com/jquery-2.0.0b1.js"></script>
-        <script src="http://code.jquery.com/jquery-migrate-1.0.0.js"></script>
+    <script src="http://code.jquery.com/jquery-2.0.0b1.js"></script>
+    <script src="http://code.jquery.com/jquery-migrate-1.0.0.js"></script>
 	<script type="text/javascript" src='../lib/rangy-1.2/rangy-core.js'></script>
 	<script type="text/javascript" src='../lib/rangy-1.2/rangy-cssclassapplier.js'></script>
 	<script type="text/javascript" src='../lib/rangy-1.2/rangy-selectionsaverestore.js'></script>
@@ -20,8 +20,6 @@
 	<script type="text/javascript" src='../src/plugins/IceEmdashPlugin/IceEmdashPlugin.js'></script>
 	<script type="text/javascript" src='../src/plugins/IceSmartQuotesPlugin/IceSmartQuotesPlugin.js'></script>
 	<script type="text/javascript" src="../lib/tinymce/jscripts/tiny_mce/tiny_mce.js"></script>
-	<script type="text/javascript" src="../lib/tinymce/jscripts/tiny_mce/tiny_mce.js"></script>
-
 </head>
 
 <body>
@@ -74,33 +72,15 @@
 					<button onclick="document.execCommand('InsertUnorderedList', null, false);">UL</button>
 					<button onclick="document.execCommand('InsertOrderedList', null, false);">OL</button>
 				</div>
-                                <div class="control">
-                                        <strong>Insert:</strong>
-                                        <button onclick="insertSampleImage();">Sample image</button>
-                                </div>
+                <div class="control">
+                        <strong>Insert:</strong>
+                        <button onclick="insertSampleImage();">Sample image</button>
+                </div>
 			</div>
 
 			<div id="content">
 				<div id="text-wrapper">
 					<div id="textbody">
-						<p><strong>Among the Wealthiest 1 Percent, Many Variations</strong><br/>By SHAILA DEWAN and ROBERT GEBELOFF</p>
-
-						
-						<p><span class="del cts-1" data-cid="2" data-userid="33" data-username="Jerri Blank" data-time="1326764311895" title="Deleted by Jerri Blank - 01/16/2012 8:38pm">Brooklyn</span><span class="ins cts-1" data-cid="3" data-userid="33" data-username="Jerri Blank" data-time="1326764319303" title="Inserted by Jerri Blank - 01/16/2012 8:38pm">Kings Point</span>, N.Y. &mdash; Adam Katz is happy to talk to reporters when he is promoting his business, a charter flight company based on Long Island called Talon Air.</p>
-						
-						<ul>
-							<li><a href="http://www.nytimes.com/packages/html/newsgraphics/2012/0115-one-percent-occupations/index.html?ref=business">The Top 1%</a></li>
-							<li><a href="http://www.nytimes.com/interactive/2012/01/15/business/one-percent-map.html?ref=business">What Percent Are You?</a></li>
-						</ul>
-
-						<p>But when the subject was his position as one of America's top earners, he <span class="del cts-1" data-cid="23" data-userid="33" data-username="Jerri Blank" data-time="1326765043953" title="Deleted by Jerri Blank - 01/16/2012 8:50pm">hesitated</span><span class="ins cts-1" data-cid="24" data-userid="33" data-username="Jerri Blank" data-time="1326765049283" title="Inserted by Jerri Blank - 01/16/2012 8:50pm">balked</span>. Seated at a desk fashioned from a jet fuel cell<span title="Inserted by Geoffrey Jellineck - 01/16/2012 8:42pm" data-time="1326764560331" data-username="Geoffrey Jellineck" data-userid="11" data-cid="20" class="ins cts-3">, wearing a button-down shirt with the company logo,</span> he considered the public relations benefits and found them lacking: "It's not very popular to be in the 1 percent these days, is it?"</p>
-
-						<p><img src="http://graphics8.nytimes.com/images/2012/01/15/business/ONEPERCENT/ONEPERCENT-popup.jpg" width="540" /></p>
-
-
-						<p><span class="ins cts-2" data-cid="14" data-userid="22" data-username="Chuck Noblet" data-time="1326764402035" title="Inserted by Chuck Noblet - 01/16/2012 8:40pm">A few months ago, Mr. Katz was just a successful businessman with <span class="del cts-3" data-cid="15" data-userid="11" data-username="Geoffrey Jellineck" data-time="1326764492624" title="Deleted by Geoffrey Jellineck - 01/16/2012 8:41pm">four</span><span class="ins cts-3" data-cid="16" data-userid="11" data-username="Geoffrey Jellineck" data-time="1326764495239" title="Inserted by Geoffrey Jellineck - 01/16/2012 8:41pm">five</span> children, an $8 million home, a family real estate company in Manhattan and his passion, 10-year-old Talon Air.</span></p>
-						
-						<p>Now, the colossal gap between the very rich and everyone else <span title="Inserted by Geoffrey Jellineck - 01/16/2012 8:46pm" data-time="1326764809499" data-username="Geoffrey Jellineck" data-userid="11" data-cid="22" class="ins cts-3">&mdash; the 1 percent versus the 99 percent &mdash; </span>has become a rallying point in this election season. As President Obama positions himself as a defender of the middle class, and Mitt Romney, the wealthiest of the Republican presidential candidates, decries such talk as "the bitter politics of envy," Mr. Katz has found himself on the wrong end of a new paradigm.</p><p><span class="ins cts-1" data-cid="30" data-userid="33" data-username="Jerri Blank" data-time="1326765098946" title="Inserted by Jerri Blank - 01/16/2012 8:51pm">As a member of the 1 percent, he is part of a club whose name conjures images of Wall Street bosses who are chauffeured from manse to Manhattan and fat cats who have armies of lobbyists at the ready.</span></p> <p>But in reality it is a far larger and more varied group, one that includes podiatrists and actuaries, executives and entrepreneurs, the self-made and the silver spoon set. They are clustered not just in New York and Los Angeles, but also in Denver and Dallas. The range of wealth in the 1 percent is vast &mdash; from households that bring in $380,000 a year, according to census data, up to billionaires like Warren E. Buffett and Bill Gates.</p><p>The top 1 percent of earners in a given year receives <a title="Related data from the Tax Policy Center." href="http://www.taxpolicycenter.org/numbers/displayatab.cfm?DocID=2972">just under a fifth</a> of the country's pretax income, <a title="A Congressional Budget Office report." href="http://www.cbo.gov/publications/collections/tax/2010/pre-tax_income_shares.pdf">about double their share</a> 30 years ago. They pay just over a fourth of all federal taxes, according to the Tax Policy Center. In 2007, they accounted for about 30 percent of philanthropic giving, according to Federal Reserve data. They received 22 percent of their income from capital gains, compared with 2 percent for everybody else.</p><p><span class="ins cts-3" data-cid="21" data-userid="11" data-username="Geoffrey Jellineck" data-time="1326764626633" title="Inserted by Geoffrey Jellineck - 01/16/2012 8:43pm">Still, they are not necessarily the idle rich. Mr. Katz, who sometimes commutes by amphibious plane and sometimes carries luggage for Talon Air passengers, likes to say he works "26/9."</span></p> <p>Most 1 percenters were born with socioeconomic advantages, which helps explain why the 1 percent is more likely than other Americans to have jobs, according to census data. They work longer hours, being three times more likely than the 99 percent to work more than 50 hours a week, and are more likely to be self-employed. Married 1 percenters are just as likely as other couples to have two incomes, but men are the big breadwinners, earning 75 percent of the money, compared with 64 percent of the income in other households.</p><p>Though many of the wealthy lean toward the Republican Party, in interviews, 1 percenters expressed a broad range of views on how to fix the economy. They think that President Obama is ruining it, or that Republicans in Congress have gone off the deep end. They favor a flat tax, or they believe the rich should pay a higher marginal rate. Some cheered on Occupy Wall Street, saying it was about time, while others wished the protesters would just get a job or take a bath. Still others were philosophical &mdash; perhaps because they could afford to be &mdash; viewing the <a href="http://topics.nytimes.com/top/reference/timestopics/subjects/r/recession_and_depression/index.html?inline=nyt-classifier" title="More articles about the recession." class="meta-classifier">recession</a> as something that would pass, like so many previous ups and downs.</p><p><span class="ins cts-2" data-cid="31" data-userid="22" data-username="Chuck Noblet" data-time="1326765165952" title="Inserted by Chuck Noblet - 01/16/2012 8:52pm">Of the 1 percenters interviewed for this article, almost all &amp;mdash; conservatives and liberals alike &amp;mdash; said the wealthy could and should shoulder more of the country's financial burden, and almost all said they viewed the current system as unfair. But they may prefer facing cuts to their own benefits like &lt;a href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/social_security_us/index.html?inline=nyt-classifier" title="More articles about Social Security." class="meta-classifier"&gt;Social Security&lt;/a&gt; than paying more taxes. In &lt;a title="The survey, by the Russell Sage Foundation." href="http://www.russellsage.org/blog/r-mascarenhas/wealthiest-1-percent-and-common-good"&gt;one survey&lt;/a&gt; of wealthy Chicago families, almost twice as many respondents said they would cut government spending as those who said they would cut spending and raise revenue.&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span></p><p>Even those who said the deck was stacked in their favor did not appreciate anti-rich rhetoric.</p><p>"I don't mind paying a little bit more in taxes. I don't mind putting money to programs that help the poor," said Anthony J. Bonomo of Manhasset, N.Y., who runs a medical malpractice insurance company and is a Republican. But, he said, he did mind taking a hit for the country's woes. "If those people could camp out in that park all day, why aren't they out looking for a job? Why are they blaming others?"</p><p>To many, 99 vs. 1 was an artificial distinction that overlooked hard work and moral character. "It shouldn't be relevant," said Mr. Katz , who said he both creates job and contributes to charitable causes. "I'm not hurting anyone. I'm helping a lot of people."</p><p><strong> The Enclave</strong></p><p>The placid sliver of Long Island that F. Scott Fitzgerald immortalized in "The Great Gatsby" as West Egg and East Egg seems almost to have shrugged off the recession.</p><p>A stretch of northwest Nassau County that includes Great Neck, Manhasset and Port Washington, this area has the country's highest concentration of 1 percenters, and one of the lowest unemployment rates in the state. Houses in Port Washington are worth only 10 percent less than they were at their peak, according to the <a href="http://topics.nytimes.com/top/reference/timestopics/subjects/s/standard_poors_caseshiller_home_price_index/index.html?inline=nyt-classifier" title="More articles about the Case-Shiller Home Price Index." class="meta-classifier">Standard &amp; Poor's Case-Shiller Home Price Index</a>, a far smaller decline than in the rest of the country. Yearly sales at the Americana Manhasset, the upscale granite and glass shopping center, have already exceeded their prerecession high. Even in down times, the 1 percent has <a title="Tables 1 and 2 in a related study (PDF). " href="http://www.treasury.gov/resource-center/tax-policy/Documents/incomemobilitystudy03-08revise.pdf">staying power</a>, being far more likely than any other group to stay where they are rather than slip to lower rungs of the economic ladder.</p>
 					</div>
 				</div>				
 			</div>
@@ -135,23 +115,19 @@
 		function toggleDel(el) {
 			var body = document.getElementById('textbody');
 			var button = $(el);
-			if ($(body).hasClass('CT-hide')) {
-				$(body).removeClass('CT-hide');
-			} else {
-				$(body).addClass('CT-hide');
-			}
+			$(body).toggleClass('CT-hide');
 		}
 
         function insertSampleImage() {
-                var range = tracker.getCurrentRange();
-                if (!ice.dom.isChildOf(range.startContainer, text)) {
-                        return false;
-                }
-                var image = document.createElement('img');
-                image.src = "http://graphics8.nytimes.com/images/2012/01/15/business/ONEPERCENT/ONEPERCENT-popup.jpg";
-                image.width = 160;
-                tracker.insert(image, range);
-                text.focus();
+            var range = tracker.getCurrentRange();
+            if (!ice.dom.isChildOf(range.startContainer, text)) {
+                return false;
+            }
+            var image = document.createElement('img');
+            image.src = "http://graphics8.nytimes.com/images/2012/01/15/business/ONEPERCENT/ONEPERCENT-popup.jpg";
+            image.width = 160;
+            tracker.insert(image, range);
+            text.focus();
         }
 
 		</script>

--- a/src/ice.js
+++ b/src/ice.js
@@ -895,9 +895,8 @@
                 commonAncestor = range.commonAncestorContainer,
                 nextContainer, returnValue;
 
-
-            // If the current block is empty then let the browser handle the delete/event.
-            if (isEmptyBlock) return false;
+            // If the current block is empty and has later siblings, then let the browser handle the delete/event.
+            if (isEmptyBlock) return !nextBlock;
 
             // Some bugs in Firefox and Webkit make the caret disappear out of text nodes, so we try to put them back in.
             if (commonAncestor.nodeType !== ice.dom.TEXT_NODE) {
@@ -1013,8 +1012,8 @@
                 commonAncestor = range.commonAncestorContainer,
                 lastSelectable, prevContainer;
 
-            // If the current block is empty, then let the browser handle the key/event.
-            if (isEmptyBlock) return false;
+            // If the current block is empty and has siblings earlier in the DOM, then let the browser handle the key/event.
+            if (isEmptyBlock) return !prevBlock;
 
             // Handle cases of the caret is at the start of a container or outside a text node
             if (initialOffset === 0 || commonAncestor.nodeType !== ice.dom.TEXT_NODE) {


### PR DESCRIPTION
Check whether an empty block is preceded (in the case of backspace) or
followed (for delete) by another block, and prevent event bubbling if
this is the case.

Also minor tidying of the demo page.
