### PR TITLE
Handles cross-domain iframe content copy and paste bug.

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -154,7 +154,8 @@
     return element;
   };
   dom.stripEnclosingTags = function (content, allowedTags) {
-    jQuery(content).find('*').not(allowedTags).replaceWith(function () {
+    var c = jQuery(content);
+    c.find('*').not(allowedTags).replaceWith(function () {
       var ret = jQuery();
       try{
 	    var $this = jQuery(this);


### PR DESCRIPTION
Added a try/catch handler to handle cross-domain iframe paste issue.
Also, addressed a jQuery bug which breaks things when trying to use replaceWith() http://bugs.jquery.com/ticket/13401

This fixes issue #56
