### PR TITLE
Fix Internet Explorer (IE) specific bugs.

### DIFF
--- a/assets.yml
+++ b/assets.yml
@@ -12,6 +12,7 @@ javascripts:
     - lib/rangy-1.2/rangy-cssclassapplier.js
     - lib/rangy-1.2/rangy-selectionsaverestore.js
     - lib/rangy-1.2/rangy-serializer.js
+    - src/missingMethods.js
     - src/ice.js
     - src/dom.js
     - src/bookmark.js

--- a/src/ice.js
+++ b/src/ice.js
@@ -1248,7 +1248,7 @@
         ctNode.insertBefore(contentNode, ctNode.firstChild);
       } else {
         ctNode = this.createIceNode('deleteType');
-        contentNode.parentElement.insertBefore(ctNode, contentNode);
+        contentNode.parentNode.insertBefore(ctNode, contentNode);
         ctNode.appendChild(contentNode);
       }
 

--- a/src/missingMethods.js
+++ b/src/missingMethods.js
@@ -1,0 +1,99 @@
+'use strict';
+
+if(typeof String.prototype.trim !== 'function') {
+  String.prototype.trim = function() {
+    return this.replace(/^\s+|\s+$/g, '');
+  }
+}
+
+// Add ECMA262-5 method binding if not supported natively
+//
+if (!('bind' in Function.prototype)) {
+  Function.prototype.bind= function(owner) {
+    var that= this;
+    if (arguments.length<=1) {
+      return function() {
+        return that.apply(owner, arguments);
+      };
+    } else {
+      var args= Array.prototype.slice.call(arguments, 1);
+      return function() {
+        return that.apply(owner, arguments.length===0? args : args.concat(Array.prototype.slice.call(arguments)));
+      };
+    }
+  };
+}
+
+// Add ECMA262-5 string trim if not supported natively
+//
+if (!('trim' in String.prototype)) {
+  String.prototype.trim= function() {
+    return this.replace(/^\s+/, '').replace(/\s+$/, '');
+  };
+}
+
+// Add ECMA262-5 Array methods if not supported natively
+//
+if (!('indexOf' in Array.prototype)) {
+  Array.prototype.indexOf= function(find, i /*opt*/) {
+    if (i===undefined) i= 0;
+    if (i<0) i+= this.length;
+    if (i<0) i= 0;
+    for (var n= this.length; i<n; i++)
+      if (i in this && this[i]===find)
+        return i;
+    return -1;
+  };
+}
+if (!('lastIndexOf' in Array.prototype)) {
+  Array.prototype.lastIndexOf= function(find, i /*opt*/) {
+    if (i===undefined) i= this.length-1;
+    if (i<0) i+= this.length;
+    if (i>this.length-1) i= this.length-1;
+    for (i++; i-->0;) /* i++ because from-argument is sadly inclusive */
+      if (i in this && this[i]===find)
+        return i;
+    return -1;
+  };
+}
+if (!('forEach' in Array.prototype)) {
+  Array.prototype.forEach= function(action, that /*opt*/) {
+    for (var i= 0, n= this.length; i<n; i++)
+      if (i in this)
+        action.call(that, this[i], i, this);
+  };
+}
+if (!('map' in Array.prototype)) {
+  Array.prototype.map= function(mapper, that /*opt*/) {
+    var other= new Array(this.length);
+    for (var i= 0, n= this.length; i<n; i++)
+      if (i in this)
+        other[i]= mapper.call(that, this[i], i, this);
+    return other;
+  };
+}
+if (!('filter' in Array.prototype)) {
+  Array.prototype.filter= function(filter, that /*opt*/) {
+    var other= [], v;
+    for (var i=0, n= this.length; i<n; i++)
+      if (i in this && filter.call(that, v= this[i], i, this))
+        other.push(v);
+    return other;
+  };
+}
+if (!('every' in Array.prototype)) {
+  Array.prototype.every= function(tester, that /*opt*/) {
+    for (var i= 0, n= this.length; i<n; i++)
+      if (i in this && !tester.call(that, this[i], i, this))
+        return false;
+    return true;
+  };
+}
+if (!('some' in Array.prototype)) {
+  Array.prototype.some= function(tester, that /*opt*/) {
+    for (var i= 0, n= this.length; i<n; i++)
+      if (i in this && tester.call(that, this[i], i, this))
+        return true;
+    return false;
+  };
+}


### PR DESCRIPTION
Somewhere in the last month we broke ICE in IE.  I've added some code, in missingMethods.js, that resolves most of the issues by adding methods which IE doesn't support by default (well known).  In another case, in ice.js, a line referenced node.parentElement instead of node.parentNode which caused an error in the handling of  delete/backspace.
