### PR TITLE
Changes to isChildOf functions to accommodate nested block elements

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -270,47 +270,43 @@
     return false;
   };
   dom.isChildOfTagName = function (el, name) {
-    var parentNode = null;
     try {
       while (el && el.parentNode) {
         if (el.parentNode && el.parentNode.tagName && el.parentNode.tagName.toLowerCase() === name) {
-          parentNode = el.parentNode;
+          return el.parentNode;
         }
         el = el.parentNode;
       }
     } catch (e) {}
-    return parentNode;
+    return false;
   };
 
 
   dom.isChildOfTagNames = function (el, names) {
-    var parentNode = null;
     try {
       while (el && el.parentNode) {
         if (el.parentNode && el.parentNode.tagName) {
           tagName = el.parentNode.tagName.toLowerCase();
           for (var i = 0; i < names.length; i++) {
             if (tagName === names[i]) {
-              parentNode = el.parentNode;
-              break;
+              return el.parentNode;
             }
           }
         }
         el = el.parentNode;
       }
     } catch (e) {}
-    return parentNode;
+    return null;
   };
 
   dom.isChildOfClassName = function (el, name) {
-    var parentNode = null;
     try {
       while (el && el.parentNode) {
-        if (jQuery(el.parentNode).hasClass(name)) parentNode = el.parentNode;
+        if (jQuery(el.parentNode).hasClass(name)) return el.parentNode;
         el = el.parentNode;
       }
     } catch (e) {}
-    return parentNode;
+    return null;
   };
   dom.cloneNode = function (elems, cloneEvents) {
     if (cloneEvents === undefined) {


### PR DESCRIPTION
These functions were traversing all the way up to the topmost block.  This came up when I tried to add blockquotes with paragraphs inside.  Elements in different paragraphs were being considered part of the same block (the blockquote).  This was causing problems when trying to push the cursor outside of a delete because it would jump across paragraphs.
