### PR TITLE
default "space" when no selection so autocorrect works on Mobile Safa...

### DIFF
--- a/src/ice.js
+++ b/src/ice.js
@@ -1512,10 +1512,15 @@
         /************************************************************************************/
 
         case 32:
-          preventDefault = true;
           var range = this.getCurrentRange();
-          this._moveRangeToValidTrackingPos(range, range.startContainer);
-          this.insert('\u00A0' , range);
+          if(!range.collapsed) {
+			      preventDefault = true;
+			      this._moveRangeToValidTrackingPos(range, range.startContainer);
+			      this.insert('\u00A0' , range);
+		      }
+		      else {
+    		  	preventDefault = false;
+		      }
           break;
         default:
           // Ignore key.


### PR DESCRIPTION
...ri

If no range is selected when the user hits "space" -- and hence is not "overwriting" a selection -- then we should allow the "space" to pass through as default rather than inserting '\u00A0'. Allowing the space to be treated default makes auto-correct continue to work on (at least) iPhones, where the "space" event is what triggers auto-correct, auto-complete, auto-capitalization, 2 spaces marking the end of a sentence, etc. Otherwise, auto-correct breaks.
