### PR TITLE
Suggestion: Update LICENSE / GPL2 or later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,9 @@
 Copyright (c) The New York Times, CMS Group, Matthew DeLambo
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License, version 2, as
-published by the Free Software Foundation.
+it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
Strict GPLv2 is incompatible with AGPLv3 and I think may be incompatible with GPLv3 also. However, if you use the 'or later' clause as recommended by FSF, then you can auto-upgrade the terms of your license as the GPL is improved. In particular, GPLv3 is semi-compatible with AGPLv3 code, which would be a big improvement for the usability of ICE.
